### PR TITLE
Clarify older version was automatically removed

### DIFF
--- a/DeckPersonalisationApi/Services/Css/ValidateCssThemeTask.cs
+++ b/DeckPersonalisationApi/Services/Css/ValidateCssThemeTask.cs
@@ -182,7 +182,7 @@ public class ValidatePublicCssThemeTask : ValidateCssThemeTask
             CssSubmission? pendingSubmission = _submissionService.GetSubmissionByThemeId(pendingSubmissionTheme.Id);
             if (pendingSubmission != null)
             {
-                _submissionService.DenyTheme(pendingSubmission.Id, "Automatically denied due to re-submission.", _userService.GetUserById(_user.Id)!);
+                _submissionService.DenyTheme(pendingSubmission.Id, "Automatically denied older version due to re-submission.", _userService.GetUserById(_user.Id)!);
             }
         }
 


### PR DESCRIPTION
Includes the text "older version" in the email sent to users when their themes are denied due to a re-submission (upload of a newer version).